### PR TITLE
Issue 116

### DIFF
--- a/scenariolib/event_click.go
+++ b/scenariolib/event_click.go
@@ -89,6 +89,8 @@ func (click *ClickEvent) Execute(v *Visit) error {
 func computeClickRank(v *Visit, clickRank, offset int) (computedRank int) {
 	computedRank = clickRank
 	if computedRank == -1 { // if rank == -1 we need to randomize a rank
+		// Default to the first result to click on
+		computedRank = 0
 		// Find a random rank within the possible click values accounting for the offset
 		if v.LastResponse.TotalCount > 1 {
 			topL := Min(v.LastQuery.NumberOfResults, v.LastResponse.TotalCount)

--- a/scenariolib/event_pageview.go
+++ b/scenariolib/event_pageview.go
@@ -92,6 +92,8 @@ func (view *ViewEvent) send(v *Visit) error {
 func computePageViewRank(v *Visit, clickRank, offset int) (computedRank int) {
 	computedRank = clickRank
 	if computedRank == -1 { // if rank == -1 we need to randomize a rank
+		// Default to the first result to click on
+		computedRank = 0
 		// Find a random rank within the possible click values accounting for the offset
 		if v.LastResponse.TotalCount > 1 {
 			topL := Min(v.LastQuery.NumberOfResults, v.LastResponse.TotalCount)


### PR DESCRIPTION
## Description
Fix for the panic index out of range on pageView events when you have only 1 result.
When the scenario specifies a `clickRank` of -1, we compute a random document rank to send as pageView rank. But if there is only 1 document in the response this randomization used to return -1 as a rank to click on...

**Fixes issue:** #116 