### PR TITLE
Fix CaseSearch producing errors

### DIFF
--- a/TESTScenarios.json
+++ b/TESTScenarios.json
@@ -1,0 +1,142 @@
+{
+  "searchendpoint": "https://platform.cloud.coveo.com/rest/search/v2",
+  "analyticsendpoint": "https://platform.cloud.coveo.com/rest/ua/v15/analytics/",
+  "defaultOriginLevel1": "BotSearch",
+  "timeBetweenVisits": 1,
+  "timeBetweenActions": 1,
+  "anonymousThreshold": 1,
+  "orgName": "SpeedBit",
+  "pipeline": "default",
+  "randomCustomData": [
+    {
+      "apiname": "customData1",
+      "values": [
+        "Speedbit Blaze"
+      ]
+    }
+  ],
+  "randomGoodQueries": [
+    "@uri"
+  ],
+  "randomBadQueries": [
+    "aaaaaaaaaaa"
+  ],
+  "randomData": {
+    "languages": [
+      "en"
+    ]
+  },
+  "scenarios": [
+    {
+      "name": "Scenarios deflected (Problem with activity goals)",
+      "weight": 1,
+      "events": [
+        {
+          "type": "SetOrigin",
+          "arguments": {
+            "originLevel1": "CommunityCaseCreation"
+          }
+        },
+        {
+          "type": "Search",
+          "arguments": {
+            "queryText": "Problem with activity goals",
+            "goodQuery": true,
+            "caseSearch": true,
+            "inputTitle": "Subject"
+          }
+        },
+        {
+          "type": "Click",
+          "arguments": {
+            "docNo": -1,
+            "offset": 0,
+            "probability": 0.8,
+            "quickview": true
+          }
+        },
+        {
+          "type": "Custom",
+          "arguments": {
+            "eventValue": "unloadPage",
+            "eventType": "caseCreation",
+            "customData": {
+              "hasclicks": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "PageView",
+      "weight": 1,
+      "events": [
+        {
+          "type": "Search",
+          "arguments": {
+            "queryText": "",
+            "goodQuery": true,
+            "ignoreEvent": true
+          }
+        },
+        {
+          "type": "View",
+          "arguments": {
+            "offset": 0,
+            "docNo": -1,
+            "probability": 1,
+            "pageViewField": "sysdocumenttype",
+            "contentType": "document"
+          }
+        }
+      ]
+    },
+    {
+      "name": "testSearchGood",
+      "weight": 1,
+      "events": [
+        {
+          "type": "Search",
+          "arguments": {
+            "queryText": "",
+            "goodQuery": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "testSearchBad",
+      "weight": 1,
+      "events": [
+        {
+          "type": "Search",
+          "arguments": {
+            "queryText": "",
+            "goodQuery": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "testSearchClick",
+      "weight": 1,
+      "events": [
+        {
+          "type": "Search",
+          "arguments": {
+            "queryText": "",
+            "goodQuery": true
+          }
+        },
+        {
+          "type": "Click",
+          "arguments": {
+            "docNo": -1,
+            "offset": 0,
+            "probability": 1
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/coveo/uabot/scenariolib"
+	"github.com/coveooss/uabot/scenariolib"
 	"github.com/k0kubun/pp"
 )
 

--- a/scenariolib/event_click.go
+++ b/scenariolib/event_click.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"math/rand"
 
-	"github.com/coveo/go-coveo/search"
+	"github.com/coveooss/go-coveo/search"
 
 	"encoding/json"
 )

--- a/scenariolib/event_fakesearch.go
+++ b/scenariolib/event_fakesearch.go
@@ -3,7 +3,7 @@
 package scenariolib
 
 import (
-	"github.com/coveo/go-coveo/search"
+	"github.com/coveooss/go-coveo/search"
 )
 
 // ============== FAKE SEARCH EVENT ======================

--- a/scenariolib/event_pageview.go
+++ b/scenariolib/event_pageview.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"math/rand"
 
-	ua "github.com/coveo/go-coveo/analytics"
+	ua "github.com/coveooss/go-coveo/analytics"
 )
 
 // ============== VIEW EVENT ======================

--- a/scenariolib/event_search.go
+++ b/scenariolib/event_search.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 
 	ua "github.com/coveooss/go-coveo/analytics"
+	"github.com/k0kubun/pp"
 )
 
 // ============== SEARCH EVENT ======================
@@ -27,7 +28,7 @@ type SearchEvent struct {
 	ActionType    string
 }
 
-const caseQuerySomeTemplate = "($some(keywords: %s, match: 1, maximum: 300)) ($sort(criteria: relevancy))"
+const caseQuerySomeTemplate = "($some(keywords: '%s', match: 1, maximum: 300))"
 const defaultSearchCause = "searchboxSubmit"
 const defaultCaseSearchCause = "inputChange"
 
@@ -75,10 +76,12 @@ func (search *SearchEvent) Execute(visit *Visit) (err error) {
 	}
 	Info.Printf("Searching for : %s", search.Keywords)
 
+	pp.Print(visit.LastQuery)
 	// Execute a search and save the response
 	if visit.LastResponse, err = visit.SearchClient.Query(*visit.LastQuery); err != nil {
 		return
 	}
+	pp.Print(visit.LastResponse.SearchUID)
 
 	// in some scenarios (logging of page views), we don't want to send the search event to the analytics
 	if !search.IgnoreEvent {

--- a/scenariolib/event_search.go
+++ b/scenariolib/event_search.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 
-	ua "github.com/coveo/go-coveo/analytics"
+	ua "github.com/coveooss/go-coveo/analytics"
 )
 
 // ============== SEARCH EVENT ======================
@@ -27,7 +27,7 @@ type SearchEvent struct {
 	ActionType    string
 }
 
-const caseQuerySomeTemplate = "($some(keywords: %s, match: 1, removeStopWords: true, maximum: 300)) ($sort(criteria: relevancy))"
+const caseQuerySomeTemplate = "($some(keywords: %s, match: 1, maximum: 300)) ($sort(criteria: relevancy))"
 const defaultSearchCause = "searchboxSubmit"
 const defaultCaseSearchCause = "inputChange"
 

--- a/scenariolib/event_search.go
+++ b/scenariolib/event_search.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 
 	ua "github.com/coveooss/go-coveo/analytics"
-	"github.com/k0kubun/pp"
 )
 
 // ============== SEARCH EVENT ======================
@@ -76,12 +75,10 @@ func (search *SearchEvent) Execute(visit *Visit) (err error) {
 	}
 	Info.Printf("Searching for : %s", search.Keywords)
 
-	pp.Print(visit.LastQuery)
 	// Execute a search and save the response
 	if visit.LastResponse, err = visit.SearchClient.Query(*visit.LastQuery); err != nil {
 		return
 	}
-	pp.Print(visit.LastResponse.SearchUID)
 
 	// in some scenarios (logging of page views), we don't want to send the search event to the analytics
 	if !search.IgnoreEvent {

--- a/scenariolib/visit.go
+++ b/scenariolib/visit.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	ua "github.com/coveo/go-coveo/analytics"
-	"github.com/coveo/go-coveo/search"
+	ua "github.com/coveooss/go-coveo/analytics"
+	"github.com/coveooss/go-coveo/search"
 	"github.com/coveo/uabot/defaults"
 )
 


### PR DESCRIPTION
## Description
The CaseSearch queries were crashing when being sent to the SearchAPI.
We were generating a query like so:
`($some(keywords: {KEYWORDS}, match: 1, removeStopWords: true, maximum: 300)) ($sort(criteria: relevancy))`

Apparently neither the `($sort(criteria: relevancy))` nor the `removeStopWords: true` are valid syntax anymore, this query crashes when being executed which is why we were seeing no more case UA in demos.

## Where should the reviewer start?
The event_search.go changes.

**Fixes issue:** #122